### PR TITLE
Add HDF5 support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,3 +11,5 @@ bx_whitelist: null
 correct_bus: True
 min_umis: 500
 targets_config: "extdata/targets/targets.yaml"
+use_hdf5: False
+include_reports: True

--- a/envs/bioconductor-sce.yaml
+++ b/envs/bioconductor-sce.yaml
@@ -4,11 +4,12 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - r-base=4.0
+  - r-base=4.1
   - r-dplyr=1.0
   - r-ggplot2=3.3
   - r-readr=2.1
   - r-stringr=1.4
-  - bioconductor-singlecellexperiment=1.10
-  - bioconductor-plyranges=1.8
+  - bioconductor-hdf5array=1.22
+  - bioconductor-singlecellexperiment=1.16
+  - bioconductor-plyranges=1.14
   - openssl=1

--- a/envs/rmd-reporting.yaml
+++ b/envs/rmd-reporting.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - r-base=4.0
+  - r-base=4.1
   - r-dplyr=1.0
   - r-ggplot2=3.3
   - r-matrix=1.4

--- a/scripts/mtxs_to_sce_genes.R
+++ b/scripts/mtxs_to_sce_genes.R
@@ -7,6 +7,7 @@ library(stringr)
 library(tibble)
 library(plyranges)
 library(Matrix)
+library(HDF5Array)
 library(SingleCellExperiment)
 
 ################################################################################
@@ -17,28 +18,43 @@ if (interactive()) {
     Snakemake <- setClass("Snakemake", slots=c(input='list', output='list', params='list'))
     snakemake <- Snakemake(
         input=list(
-            bxs=c("data/kallisto/utrome_hg38_v1/pbmc_1k_v2_fastq/genes.barcodes.txt"),
-            genes=c("data/kallisto/utrome_hg38_v1/pbmc_1k_v2_fastq/genes.genes.txt"),
-            mtxs=c("data/kallisto/utrome_hg38_v1/pbmc_1k_v2_fastq/genes.mtx"),
+            bxs=c("data/kallisto/utrome_hg38_v1/pbmc_1k_v2_fastq/genes.barcodes.txt",
+                  "data/kallisto/utrome_hg38_v1/pbmc_1k_v2_fastq/genes.barcodes.txt"),
+            genes=c("data/kallisto/utrome_hg38_v1/pbmc_1k_v2_fastq/genes.genes.txt",
+                  "data/kallisto/utrome_hg38_v1/pbmc_1k_v2_fastq/genes.genes.txt"),
+            mtxs=c("data/kallisto/utrome_hg38_v1/pbmc_1k_v2_fastq/genes.mtx",
+                   "data/kallisto/utrome_hg38_v1/pbmc_1k_v2_fastq/genes.mtx"),
             gtf="extdata/targets/utrome_hg38_v1/utrome.e30.t5.gc39.pas3.f0.9999.w500.gtf",
             gene_annots=NULL,
             cell_annots="examples/pbmc_1k_v2_fastq/annots.csv"),
-        output=list(sce="data/sce/utrome_hg38_1/test.utrome.genes.Rds"),
+        output=list(sce="data/sce/utrome_hg38_v1/test.utrome.genes.se.rds",
+                    hdf5="data/sce/utrome_hg38_v1/test.utrome.genes.assays.h5"),
         params=list(genome='hg38',
-                    sample_ids=c("pbmc_1k_v2_fastq"),
+                    sample_ids=c("pbmc_1k_v2_fastq_1", "pbmc_1k_v2_fastq_2"),
                     min_umis="500",
-                    cell_annots_key="cell_id"))
+                    cell_annots_key="cell_id",
+                    tmp_dir=tempdir(),
+                    use_hdf5=TRUE))
 }
 
 ################################################################################
 # Helper Functions
 ################################################################################
 is_na_all <- function (v) { all(is.na(v)) }
+
 drop_na_mcols <- function (gr) {
     cols_to_rm <- mcols(gr) %>%
         apply(2, is_na_all) %>%
         which %>% names
     select(gr, -cols_to_rm)
+}
+
+optional_hdf5_convert <- if (snakemake@params$use_hdf5) {
+    dir.create(snakemake@params$tmp_dir, recursive=TRUE)
+    setHDF5DumpDir(snakemake@params$tmp_dir)
+    writeTENxMatrix
+} else {
+    identity
 }
 
 ################################################################################
@@ -48,11 +64,12 @@ drop_na_mcols <- function (gr) {
 gr_gtf <- read_gff(snakemake@input$gtf, genome_info=snakemake@params$genome,
                    col_names=c('type', 'transcript_id', 'gene_id',
                                'gene_name', 'transcript_name', 'utr_name', 'utr_rank'))
+
 grl_genes <- gr_gtf %>%
     filter(type == 'transcript') %>%
 
     ## remove unneeded or missing columns
-    select(-c('type', 'gene_name')) %>%
+    select(-all_of(c('type', 'gene_name'))) %>%
     drop_na_mcols %>%
 
     ## add rownames
@@ -103,6 +120,7 @@ load_mtx_to_sce <- function (mtxFile, bxFile, geneFile, sample_id) {
             gene_id=read_lines(geneFile))) %>%
         t %>%
         { .[, colSums(.) >= as.integer(snakemake@params$min_umis)] } %>%
+        optional_hdf5_convert() %>%
         { SingleCellExperiment(assays=list(counts=.),
                                colData=DataFrame(cell_id=colnames(.),
                                                  sample_id=sample_id,
@@ -137,4 +155,11 @@ rowData(sce) <- df_gene_annots[rownames(sce), ]
 # Export SCE
 ################################################################################
 
-saveRDS(sce, snakemake@output$sce)
+if (snakemake@params$use_hdf5) {
+    saveHDF5SummarizedExperiment(sce, dir=dirname(snakemake@output$sce),
+                                 prefix=str_remove(basename(snakemake@output$sce), "se.rds$"),
+                                 as.sparse=TRUE, verbose=TRUE)
+    unlink(snakemake@params$tmp_dir, recursive=TRUE, force=TRUE)
+} else {
+    saveRDS(sce, snakemake@output$sce)
+}


### PR DESCRIPTION
# Large Datasets
We add a new boolean option, `use_hdf5`, to output a HDF5-backed `SingleCellExperiment` object. This mode is disabled by default, and can be enabled by adding `use_hdf5: True` to a configuration YAML file.

In this mode, the pipeline will emit both an `.rds` and a `.h5` file to the `data/sce/{target}/` folder. Both files must be colocated in order to load the object. The `HDF5Array::loadHDF5SummarizedExperiment` must be used to load the `SingleCellExperiment` object. For example, given a `{dataset_name}` and `{target}`, one would load a `txs` output with:

```r
library(HDF5Array)
library(SingleCellExperiment)

sce_txs <- loadHDF5SummarizedExperiment("data/sce/{target}", "dataset_name.txs.")
```

Please note the trailing `.` in the prefix argument.

closes #55 

# Optional Reporting
We add a new boolean option, `include_reports`, which is on by default. Add `include_reports: False` to a configuration YAML file to disable R Markdown reporting.

closes #14 

# Upgrading to Bioconductor 3.14
The YAML environment definitions have been updated to use R 4.1 and Bioconductor 3.14 packages.

closes #31 