### PR TITLE
Support parallelized MTX loading

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -306,7 +306,8 @@ rule mtxs_to_sce_h5_txs:
         tmp_dir=lambda wcs: config['tmp_dir'] + "/sce-txs-" + wcs.target + "-" + config['dataset_name'],
         use_hdf5=True
     resources:
-        mem_mb=16000
+        mem_mb=8000
+    threads: 8
     conda: "envs/bioconductor-sce.yaml"
     script:
         "scripts/mtxs_to_sce_txs.R"
@@ -333,7 +334,8 @@ rule mtxs_to_sce_h5_genes:
         tmp_dir=lambda wcs: config['tmp_dir'] + "/sce-genes-" + wcs.target + "-" + config['dataset_name'],
         use_hdf5=True
     resources:
-        mem_mb=16000
+        mem_mb=8000
+    threads: 8
     conda: "envs/bioconductor-sce.yaml"
     script:
         "scripts/mtxs_to_sce_genes.R"

--- a/scripts/mtxs_to_sce_genes.R
+++ b/scripts/mtxs_to_sce_genes.R
@@ -9,13 +9,15 @@ library(plyranges)
 library(Matrix)
 library(HDF5Array)
 library(SingleCellExperiment)
+library(BiocParallel)
 
 ################################################################################
 # Fake Data (Interactive Testing)
 ################################################################################
 
 if (interactive()) {
-    Snakemake <- setClass("Snakemake", slots=c(input='list', output='list', params='list'))
+    Snakemake <- setClass("Snakemake", slots=c(input='list', output='list',
+                                               params='list', threads='numeric'))
     snakemake <- Snakemake(
         input=list(
             bxs=c("data/kallisto/utrome_hg38_v1/pbmc_1k_v2_fastq/genes.barcodes.txt",
@@ -33,8 +35,9 @@ if (interactive()) {
                     sample_ids=c("pbmc_1k_v2_fastq_1", "pbmc_1k_v2_fastq_2"),
                     min_umis="500",
                     cell_annots_key="cell_id",
-                    tmp_dir=tempdir(),
-                    use_hdf5=TRUE))
+                    tmp_dir=tempdir(check=TRUE),
+                    use_hdf5=TRUE),
+        threads=4L)
 }
 
 ################################################################################
@@ -127,12 +130,13 @@ load_mtx_to_sce <- function (mtxFile, bxFile, geneFile, sample_id) {
                                                  row.names=colnames(.))) }
 }
 
+register(MulticoreParam(snakemake@threads))
 
-sce <- mapply(load_mtx_to_sce,
-              mtxFile=snakemake@input$mtxs,
-              bxFile=snakemake@input$bxs,
-              geneFile=snakemake@input$genes,
-              sample_id=snakemake@params$sample_ids) %>%
+sce <- bpmapply(load_mtx_to_sce,
+                mtxFile=snakemake@input$mtxs,
+                bxFile=snakemake@input$bxs,
+                geneFile=snakemake@input$genes,
+                sample_id=snakemake@params$sample_ids) %>%
     do.call(what=cbind)
 
 ################################################################################
@@ -156,9 +160,10 @@ rowData(sce) <- df_gene_annots[rownames(sce), ]
 ################################################################################
 
 if (snakemake@params$use_hdf5) {
+    chunkdim <- c(dim(sce)[[1]], min(1e3L, dim(sce)[[2]]))
     saveHDF5SummarizedExperiment(sce, dir=dirname(snakemake@output$sce),
                                  prefix=str_remove(basename(snakemake@output$sce), "se.rds$"),
-                                 as.sparse=TRUE, verbose=TRUE)
+                                 chunkdim=chunkdim, as.sparse=TRUE, verbose=TRUE)
     unlink(snakemake@params$tmp_dir, recursive=TRUE, force=TRUE)
 } else {
     saveRDS(sce, snakemake@output$sce)


### PR DESCRIPTION
This dramatically improves load times for large, multi-sample datasets destined for HDF5 output. This does not update the default `threads` or memory usage for the non-HDF5-backed mode of output. For now, we assume that those with large datasets will use HDF5 mode, and smaller datasets can continue using the default mode.

There could be benefits to the default mode for multi-sample settings, but we have not benchmarked this.

Closes #57 