### PR TITLE
Avoid `sample_id` collision

### DIFF
--- a/scripts/mtxs_to_sce_genes.R
+++ b/scripts/mtxs_to_sce_genes.R
@@ -133,7 +133,7 @@ load_mtx_to_sce <- function (mtxFile, bxFile, geneFile, sample_id) {
         optional_hdf5_convert %>%
         { SingleCellExperiment(assays=list(counts=.),
                                colData=DataFrame(cell_id=colnames(.),
-                                                 sample_id=sample_id,
+                                                 sample_id.sq=sample_id,
                                                  row.names=colnames(.))) }
 }
 

--- a/scripts/mtxs_to_sce_txs.R
+++ b/scripts/mtxs_to_sce_txs.R
@@ -133,7 +133,7 @@ load_mtx_to_sce <- function (mtxFile, bxFile, txFile, sample_id) {
         optional_hdf5_convert %>%
         { SingleCellExperiment(assays=list(counts=.),
                                colData=DataFrame(cell_id=colnames(.),
-                                                 sample_id=sample_id,
+                                                 sample_id.sq=sample_id,
                                                  row.names=colnames(.))) }
 }
 


### PR DESCRIPTION
This naively attempts to avoid `sample_id` column collisions when attaching cell annotations by using `sample_id.sq` for the sample IDs used in scUTRquant.

Closes #64.