### PR TITLE
Adds support for H5AD (AnnData) output

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,20 +44,31 @@ determined by simulations.
 Please see [our accompanying manuscript][ref:scUTRquant] for more details.
 
 ## Outputs
+### SingleCellExperiment object (*default*)
 The primary output of the pipeline is a Bioconductor `SingleCellExperiment` object.
 The `counts` in the object is a sparse `Matrix` of 3' UTR isoform counts; the `rowRanges` 
 is a `GenomicRanges` of the 3' UTR isoforms; the `rowData` is a `DataFrame` with additional
 information about 3' UTR isoforms; and the `colData` is a `DataFrame` populated with sample 
 metadata and optional user-provide cell annotations.
 
+### H5AD AnnData object (*experimental*)
+scUTRquant v0.5.0 adds support for [AnnData objects](https://anndata.readthedocs.io/en/stable/index.html),
+making it easier for users who prefer Python and working with [the `scverse` ecosystem](https://scverse.org).
+Similar annotations will be attached in the `obs` (cell) and `var` (3'UTR isoform) tables.
+However, no analogous `rowRanges` is attached.
+
+The output format can be controlled with the `output_format` configuration option,
+with `"h5ad"` and "`sce`" being currently supported options. 
+
+### Reporting
 To assist users in quality control, the pipeline additionally generates HTML reports 
 for each sample.
 
+### Additional Files
 The pipeline is configured to retain intermediate files, such as BUS and MTX files.
 Advanced users can readily customize the pipeline to only generate the files they 
-require. For example, users who prefer to work with alternative scRNA-seq data structures,
-such as those used in Scanpy or Seurat, may wish to terminate the pipeline at MTX 
-generation.
+require. For example, users who prefer to work with alternative scRNA-seq data structures
+may wish to terminate the pipeline at MTX generation.
 
 # Setup
 
@@ -237,6 +248,7 @@ pipeline. The following keys are expected:
  - `cell_annots`: (optional) CSV file with a key column that matches the `<sample_id>_<cell_bx>` format
  - `cell_annots_key`: specifies the name of the key column in the `cell_annots` file; default is `cell_id`
  - `exclude_unannotated_cells`: boolean indicating whether unannotated cells should be excluded from the final output; default is `False`
+ - `output_format`: a list of formats, `"sce"` (*default*) and/or `"h5ad"` (*experimental*); `null` will end processing at MTX files.
  
 ### Default Values
 
@@ -271,7 +283,9 @@ The `extdata/targets.yaml` defines the targets available to pseudoalign to. The 
  - `kdx`: Kallisto index for UTRome
  - `merge`: TSV for merging features (isoforms)
  - `tx_annots`: (optional) RDS file containing Bioconductor DataFrame object with annotations for transcripts
+ - `tx_annots_csv`: (optional) CSV file with annotations for transcripts (used for AnnData)
  - `gene_annots`: (optional) RDS file containing Bioconductor DataFrame object with annotations for genes
+ - `gene_annots_csv`: (optional) CSV file with annotations for genes (used for AnnData)
 
 
 # Customization

--- a/Snakefile
+++ b/Snakefile
@@ -57,8 +57,6 @@ if config['cell_annots'] is None:
 wildcard_constraints:
     sample_id=config['sample_regex']
 
-message(config)
-
 # get list of expected outputs
 def get_outputs():
     outputs = []
@@ -446,7 +444,6 @@ rule mtxs_to_h5ad_genes:
     conda: "envs/anndata.yaml"
     script:
         "scripts/mtxs_to_h5ad_genes.py"
-
 
 ################################################################################
 ## Reports

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,8 @@ target: "utrome_mm10_v2"
 output_type:
   - "txs"
   - "genes"
+output_format:
+  - "sce"
 tmp_dir: "/tmp"
 bx_whitelist: null
 correct_bus: True

--- a/envs/anndata.yaml
+++ b/envs/anndata.yaml
@@ -1,0 +1,11 @@
+name: anndata
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python=3.11
+  - anndata=0.10
+  - numpy=1.26
+  - pandas=2.2
+  - scipy=1.13

--- a/extdata/targets/targets.yaml
+++ b/extdata/targets/targets.yaml
@@ -5,7 +5,9 @@ utrome_mm10_v1:
   kdx: "adult.utrome.e3.t200.f0.999.w500.kdx"
   merge_tsv: "adult.utrome.e3.t200.f0.999.w500.merge.tsv"
   tx_annots: "utrome_txs_annotation.Rds"
+  tx_annots_csv: null
   gene_annots: "utrome_genes_annotation.Rds"
+  gene_annots_csv: null
   download_script: "download_utrome.sh"
 
 utrome_mm10_v2:
@@ -15,7 +17,9 @@ utrome_mm10_v2:
   kdx: "utrome.e30.t5.gc25.pas3.f0.9999.w500.kdx"
   merge_tsv: "utrome.e30.t5.gc25.pas3.f0.9999.w500.m200.tsv"
   tx_annots: "utrome_mm10_v2_tx_annots.2024.05.13.Rds"
+  tx_annots_csv: "utrome_mm10_v2_tx_annots.2024.05.13.csv.gz"
   gene_annots: "utrome_mm10_v2_gene_annots.2024.05.13.Rds"
+  gene_annots_csv: "utrome_mm10_v2_gene_annots.2024.05.13.csv.gz"
   download_script: "download_utrome.sh"
 
 utrome_hg38_v1:
@@ -25,7 +29,9 @@ utrome_hg38_v1:
   kdx: "utrome.e30.t5.gc39.pas3.f0.9999.w500.kdx"
   merge_tsv: "utrome.e30.t5.gc39.pas3.f0.9999.w500.m200.tsv"
   tx_annots: "utrome_hg38_v1_tx_annots.2024.05.13.Rds"
+  tx_annots_csv: "utrome_hg38_v1_tx_annots.2024.05.13.csv.gz"
   gene_annots: "utrome_hg38_v1_gene_annots.2024.05.13.Rds"
+  gene_annots_csv: "utrome_hg38_v1_gene_annots.2024.05.13.csv.gz"
   download_script: "download_utrome.sh"
 
 ## example custom target using GENCODE

--- a/scripts/mtxs_to_h5ad_genes.py
+++ b/scripts/mtxs_to_h5ad_genes.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+import os
+import pandas as pd
+from scipy.io import mmread
+import numpy as np
+from anndata import AnnData
+import anndata as ad
+from sys import stderr
+
+# print to stderr
+def message(*args, **kwargs):
+    print(*args, file=stderr, **kwargs)
+
+# Helper function to load and process MTX files
+def load_mtx_to_anndata(mtx_file, bx_file, gene_file, sample_id, min_umis, 
+                        cell_annots_df, cell_annots_key, exclude_unannotated_cells):
+    message("[INFO]    reading counts...")
+    mtx = mmread(mtx_file).tocsr()
+
+    message("[INFO]    reading barcodes...")
+    bxs = pd.read_csv(bx_file, header=None, index_col=None).iloc[:, 0].values
+    cell_ids = [f"{sample_id}_{bx}" for bx in bxs]
+    
+    message("[INFO]    reading genes...")
+    genes = pd.read_csv(gene_file, header=None, index_col=None).iloc[:, 0].values
+    
+    message("[INFO]    creating object...")
+    adata = AnnData(X=mtx, 
+                    obs=pd.DataFrame(index=cell_ids), 
+                    var=pd.DataFrame(index=genes))
+    
+    # Filter unannotated cells
+    if exclude_unannotated_cells:
+        message("[INFO]    filtering unannotated cells...")
+        annotated_cells = cell_annots_df[cell_annots_key].values
+        adata = adata[adata.obs.index.isin(annotated_cells)]
+    
+    message(f"[INFO]    filtering barcodes fewer than {min_umis} UMIs...")
+    adata = adata[adata.obs.index[adata.X.sum(axis=1).A1 >= min_umis]]
+    
+    return adata.copy()
+
+# Main processing function
+def process_mtx_files(snakemake):
+    mtx_files = snakemake.input.mtxs
+    bx_files = snakemake.input.bxs
+    gene_files = snakemake.input.genes
+    sample_ids = snakemake.params.sample_ids
+    gene_annots_file = snakemake.input.gene_annots
+    cell_annots_file = snakemake.input.cell_annots
+    cell_annots_key = snakemake.params.cell_annots_key
+    min_umis = int(snakemake.params.min_umis)
+    exclude_unannotated_cells = snakemake.params.exclude_unannotated_cells
+    output_file = snakemake.output.h5ad
+    
+    
+    if cell_annots_file:
+        cell_annots_df = pd.read_csv(cell_annots_file)
+    elif exclude_unannotated_cells:
+        message("[Warning] The `exclude_unannotated_cells` option is ignored because no `cell_annots` were provided!")
+        exclude_unannotated_cells = False
+    
+    message("[INFO] Beginning sample loading...")
+    adatas = []
+    for mtx, bx, gene, sample_id in zip(mtx_files, bx_files, gene_files, sample_ids):
+        message(f"[INFO]   Loading sample {sample_id}...")
+        adata = load_mtx_to_anndata(mtx, bx, gene, sample_id, min_umis, cell_annots_df, cell_annots_key, exclude_unannotated_cells)
+        adatas.append(adata)
+    message("[INFO] Done loading.")
+    
+    message("[INFO] Concatenating AnnData objects...")
+    combined_adata = ad.concat(adatas, axis=0)
+    
+    if gene_annots_file:
+        message("[INFO] Loading gene annotations...")
+        gene_annots_df = pd.read_csv(gene_annots_file).set_index("gene_id", drop=False)
+        message("[INFO] Attaching gene annotations...")
+        combined_adata.var = combined_adata.var.join(gene_annots_df, how='left')
+    
+    if cell_annots_file:
+        message("[INFO] Attaching cell annotations...")
+        combined_adata.obs = combined_adata.obs.join(cell_annots_df.set_index(cell_annots_key, drop=False), how='left')
+    
+    message(f"[INFO] Saving AnnData to {output_file}...")
+    combined_adata.write(output_file)
+
+# Check for snakemake object and process
+try:
+    snakemake                     # type: ignore
+    process_mtx_files(snakemake)  # type: ignore
+    message("[INFO] Done.")
+except NameError:
+    message("[WARNING] This script is intended to be executed as part of a Snakemake workflow and requires the 'snakemake' object.")
+    message("[INFO] Nothing done.")

--- a/scripts/mtxs_to_h5ad_txs.py
+++ b/scripts/mtxs_to_h5ad_txs.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+import os
+import pandas as pd
+from scipy.io import mmread
+import numpy as np
+from anndata import AnnData
+import anndata as ad
+from sys import stderr
+
+# print to stderr
+def message(*args, **kwargs):
+    print(*args, file=stderr, **kwargs)
+
+# Helper function to load and process MTX files
+def load_mtx_to_anndata(mtx_file, bx_file, tx_file, sample_id, min_umis, 
+                        cell_annots_df, cell_annots_key, exclude_unannotated_cells):
+    message("[INFO]    reading counts...")
+    mtx = mmread(mtx_file).tocsr()
+
+    message("[INFO]    reading barcodes...")
+    bxs = pd.read_csv(bx_file, header=None, index_col=None).iloc[:, 0].values
+    cell_ids = [f"{sample_id}_{bx}" for bx in bxs]
+    
+    message("[INFO]    reading transcripts...")
+    txs = pd.read_csv(tx_file, header=None, index_col=None).iloc[:, 0].values
+    
+    message("[INFO]    creating object...")
+    adata = AnnData(X=mtx, 
+                    obs=pd.DataFrame(index=cell_ids), 
+                    var=pd.DataFrame(index=txs))
+    
+    # Filter unannotated cells
+    if exclude_unannotated_cells:
+        message("[INFO]    filtering unannotated cells...")
+        annotated_cells = cell_annots_df[cell_annots_key].values
+        adata = adata[adata.obs.index.isin(annotated_cells)]
+    
+    message(f"[INFO]    filtering barcodes fewer than {min_umis} UMIs...")
+    adata = adata[adata.obs.index[adata.X.sum(axis=1).A1 >= min_umis]]
+    
+    return adata.copy()
+
+# Main processing function
+def process_mtx_files(snakemake):
+    mtx_files = snakemake.input.mtxs
+    bx_files = snakemake.input.bxs
+    tx_files = snakemake.input.txs
+    sample_ids = snakemake.params.sample_ids
+    tx_annots_file = snakemake.input.tx_annots
+    cell_annots_file = snakemake.input.cell_annots
+    cell_annots_key = snakemake.params.cell_annots_key
+    min_umis = int(snakemake.params.min_umis)
+    exclude_unannotated_cells = snakemake.params.exclude_unannotated_cells
+    output_file = snakemake.output.h5ad
+    
+    
+    if cell_annots_file:
+        cell_annots_df = pd.read_csv(cell_annots_file)
+    elif exclude_unannotated_cells:
+        message("[Warning] The `exclude_unannotated_cells` option is ignored because no `cell_annots` were provided!")
+        exclude_unannotated_cells = False
+    
+    message("[INFO] Beginning sample loading...")
+    adatas = []
+    for mtx, bx, tx, sample_id in zip(mtx_files, bx_files, tx_files, sample_ids):
+        message(f"[INFO]   Loading sample {sample_id}...")
+        adata = load_mtx_to_anndata(mtx, bx, tx, sample_id, min_umis, cell_annots_df, cell_annots_key, exclude_unannotated_cells)
+        adatas.append(adata)
+    message("[INFO] Done loading.")
+    
+    message("[INFO] Concatenating AnnData objects...")
+    combined_adata = ad.concat(adatas, axis=0)
+    
+    if tx_annots_file:
+        message("[INFO] Loading transcript annotations...")
+        tx_annots_df = pd.read_csv(tx_annots_file).set_index("transcript_id", drop=False)
+        message("[INFO] Attaching transcript annotations...")
+        combined_adata.var = combined_adata.var.join(tx_annots_df, how='left')
+    
+    if cell_annots_file:
+        message("[INFO] Attaching cell annotations...")
+        combined_adata.obs = combined_adata.obs.join(cell_annots_df.set_index(cell_annots_key, drop=False), how='left')
+    
+    message(f"[INFO] Saving AnnData to {output_file}...")
+    combined_adata.write(output_file)
+
+# Check for snakemake object and process
+try:
+    snakemake                     # type: ignore
+    process_mtx_files(snakemake)  # type: ignore
+    message("[INFO] Done.")
+except NameError:
+    message("[WARNING] This script is intended to be executed as part of a Snakemake workflow and requires the 'snakemake' object.")
+    message("[INFO] Nothing done.")


### PR DESCRIPTION
Resolves #63 

Importantly makes backward compatible extensions to:

- **target** definition: targets now have optional `tx_annots_csv` and `gene_annots_csv` slots
- **config** definition: now includes a `output_format` key that supports a `list` with support for `"sce"` and `"h5ad"`

Tested locally.