### PR TITLE
fix: switch from Figshare urls to GitHub

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,6 +1,6 @@
 container: "docker://mfansler/scutr-quant:0.5.0"
 configfile: "config.yaml"
-SQ_VERSION="0.5.0"
+SQ_VERSION="0.5.1"
 
 import os
 import pandas as pd

--- a/extdata/targets/utrome_hg38_v1/download_utrome.sh
+++ b/extdata/targets/utrome_hg38_v1/download_utrome.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 # hg38 UTRome 2022.06
-wget -O tmp.tar.gz "https://figshare.com/ndownloader/files/35874803?private_link=9f97fd9772574bee6a61" \
+wget -O tmp.tar.gz "https://github.com/Mayrlab/hcl-utrome/releases/download/v1.0.0/utrome.e30.t5.gc39.pas3.f0.9999.w500.tar.gz" \
     && tar -xvzf tmp.tar.gz \
     && rm tmp.tar.gz
 
 # hg38 Annotations
 ## txs
-wget -O utrome_hg38_v1_tx_annots.2024.05.13.csv.gz "https://figshare.com/ndownloader/files/46407826?private_link=9f97fd9772574bee6a61"
-wget -O utrome_hg38_v1_tx_annots.2024.05.13.Rds "https://figshare.com/ndownloader/files/46407829?private_link=9f97fd9772574bee6a61"
+wget -O utrome_hg38_v1_tx_annots.2024.05.13.csv.gz "https://github.com/Mayrlab/atlas-hs/releases/download/v0.1.0/utrome_hg38_v1_tx_annots.2024.05.13.csv.gz"
+wget -O utrome_hg38_v1_tx_annots.2024.05.13.Rds "https://github.com/Mayrlab/atlas-hs/releases/download/v0.1.0/utrome_hg38_v1_tx_annots.2024.05.13.Rds"
 
 ## genes
-wget -O utrome_hg38_v1_gene_annots.2024.05.13.csv.gz "https://figshare.com/ndownloader/files/46407820?private_link=9f97fd9772574bee6a61"
-wget -O utrome_hg38_v1_gene_annots.2024.05.13.Rds "https://figshare.com/ndownloader/files/46407823?private_link=9f97fd9772574bee6a61"
+wget -O utrome_hg38_v1_gene_annots.2024.05.13.csv.gz "https://github.com/Mayrlab/atlas-hs/releases/download/v0.1.0/utrome_hg38_v1_gene_annots.2024.05.13.csv.gz"
+wget -O utrome_hg38_v1_gene_annots.2024.05.13.Rds "https://github.com/Mayrlab/atlas-hs/releases/download/v0.1.0/utrome_hg38_v1_gene_annots.2024.05.13.Rds"

--- a/extdata/targets/utrome_mm10_v1/download_utrome.sh
+++ b/extdata/targets/utrome_mm10_v1/download_utrome.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 # mm10 UTRome 2019.05
-wget -O tmp.tar.gz "https://ndownloader.figshare.com/files/24989696?private_link=2d0776b1d28138a5e716" \
+wget -O tmp.tar.gz "https://github.com/Mayrlab/mca-utrome/releases/download/v1.0/utrome.w500.2019.05.tar.gz" \
     && tar -xvzf tmp.tar.gz --strip-components=1 \
     && rm tmp.tar.gz
 
 # mm10 Atlas 2021.07
 ## txs
-wget -O utrome_txs_annotation.Rds 'https://ndownloader.figshare.com/files/28873656?private_link=fa4677423a901fe137b2'
+wget -O utrome_txs_annotation.Rds 'https://github.com/Mayrlab/atlas-mm/releases/download/v0.1/utrome_txs_annotation.Rds'
 
 ## genes
-wget -O utrome_genes_annotation.Rds 'https://ndownloader.figshare.com/files/28873650?private_link=fa4677423a901fe137b2'
+wget -O utrome_genes_annotation.Rds 'https://github.com/Mayrlab/atlas-mm/releases/download/v0.1/utrome_genes_annotation.Rds'

--- a/extdata/targets/utrome_mm10_v2/download_utrome.sh
+++ b/extdata/targets/utrome_mm10_v2/download_utrome.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 # mm10 UTRome 2022.08
-wget -O tmp.tar.gz "https://figshare.com/ndownloader/files/36677958?private_link=78bbfa3c5e58a8cc5275" \
+wget -O tmp.tar.gz "https://github.com/Mayrlab/mca-utrome/releases/download/v2.0.1/utrome.e30.t5.gc25.pas3.f0.9999.w500.tar.gz" \
     && tar -xvzf tmp.tar.gz \
     && rm tmp.tar.gz
 
 # mm10 Annotations
 ## txs
-wget -O utrome_mm10_v2_tx_annots.2024.05.13.csv.gz "https://figshare.com/ndownloader/files/46407730?private_link=78bbfa3c5e58a8cc5275"
-wget -O utrome_mm10_v2_tx_annots.2024.05.13.Rds "https://figshare.com/ndownloader/files/46407733?private_link=78bbfa3c5e58a8cc5275"
+wget -O utrome_mm10_v2_tx_annots.2024.05.13.csv.gz "https://github.com/Mayrlab/atlas-mm/releases/download/v0.2.0/utrome_mm10_v2_tx_annots.2024.05.13.csv.gz"
+wget -O utrome_mm10_v2_tx_annots.2024.05.13.Rds "https://github.com/Mayrlab/atlas-mm/releases/download/v0.2.0/utrome_mm10_v2_tx_annots.2024.05.13.Rds"
 
 ## genes
-wget -O utrome_mm10_v2_gene_annots.2024.05.13.csv.gz "https://figshare.com/ndownloader/files/46407724?private_link=78bbfa3c5e58a8cc5275"
-wget -O utrome_mm10_v2_gene_annots.2024.05.13.Rds "https://figshare.com/ndownloader/files/46407727?private_link=78bbfa3c5e58a8cc5275"
+wget -O utrome_mm10_v2_gene_annots.2024.05.13.csv.gz "https://github.com/Mayrlab/atlas-mm/releases/download/v0.2.0/utrome_mm10_v2_gene_annots.2024.05.13.csv.gz"
+wget -O utrome_mm10_v2_gene_annots.2024.05.13.Rds "https://github.com/Mayrlab/atlas-mm/releases/download/v0.2.0/utrome_mm10_v2_gene_annots.2024.05.13.Rds"


### PR DESCRIPTION
Resolves #100

This removes reliability on Figshare and uses GitHub URLs. The target files were originally generated in other repositories, and so these have now be attached to Releases on those repositories. Namely,

**utrome_hg38_v1**
- https://github.com/Mayrlab/hcl-utrome/releases/v1.0.0
- https://github.com/Mayrlab/atlas-hs/releases/v0.1.0

**utrome_mm10_v1**
- https://github.com/Mayrlab/mca-utrome/releases/v1.0
- https://github.com/Mayrlab/atlas-mm/releases/v0.1

**utrome_mm10_v2**
- https://github.com/Mayrlab/mca-utrome/releases/v2.0.1
- https://github.com/Mayrlab/atlas-mm/releases/v0.2.0

Will merge after assessing workflow run: https://github.com/mfansler/scUTRquant-demo/actions/runs/21340203258/job/61418349958